### PR TITLE
fix parsing sklearn exception

### DIFF
--- a/chicksexer/_encoder.py
+++ b/chicksexer/_encoder.py
@@ -60,7 +60,7 @@ class CharEncoder(object):
                     word_id2char_ids.append(self._label_encoder.transform(list(word)).tolist())
                 except ValueError as exception:
                     unseen_chars = regex.search(
-                        r'y contains new labels: (.*)$', exception.args[0]).groups()[0]
+                        r'y contains new labels: (.*)$', exception.args[0], flags=regex.DOTALL).groups()[0]
                     raise UnseenCharacterException('Unseen characters: {}'.format(unseen_chars))
 
             name_id2word_id2char_ids.append(word_id2char_ids)


### PR DESCRIPTION
I have got exception 
`  File "<ipython-input-15-a70f92b3f371>", line 1, in <module>
    regex.search(r'y contains new labels: (.*)$', sting).groups()
AttributeError: 'NoneType' object has no attribute 'groups'`

The reason that sklearn uses numpy `setdiff1d` for formatting error, which add new line into string.

Run:
```
name = 'John Doe \U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f'
from chicksexer import predict_gender
predict_gender(name)
```
Got:
```
2018-06-20 09:34:33,483 - chicksexer.api - INFO - Loading model (only required for the initial prediction)...
Traceback (most recent call last):
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/_encoder.py", line 60, in encode
    word_id2char_ids.append(self._label_encoder.transform(list(word)).tolist())
  File "/home/user/myproj/.env/lib/python3.6/site-packages/sklearn/preprocessing/label.py", line 153, in transform
    raise ValueError("y contains new labels: %s" % str(diff))
ValueError: y contains new labels: ['\U000e0062' '\U000e0063' '\U000e0067' '\U000e0073' '\U000e0074'
 '\U000e007f']
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/user/myproj/.env/lib/python3.6/site-packages/IPython/core/interactiveshell.py", line 2963, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-21-43fd98f0889b>", line 1, in <module>
    predict_gender(name)
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/api.py", line 103, in predict_gender
    return_value = predict_genders([name], return_proba, return_attention, neutral_cutoff)
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/api.py", line 63, in predict_genders
    names, return_proba, return_attention, low_cutoff=low_cutoff, high_cutoff=high_cutoff)
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/classifier.py", line 242, in predict
    X = self._encode_chars(names)
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/classifier.py", line 430, in _encode_chars
    name_id2word_id2char_ids = self._encoder.encode(names)
  File "/home/user/myproj/.env/lib/python3.6/site-packages/chicksexer/_encoder.py", line 63, in encode
    r'y contains new labels: (.*)$', exception.args[0]).groups()[0]
AttributeError: 'NoneType' object has no attribute 'groups'
```